### PR TITLE
Create package with term search functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,92 @@
 # pyphenoscape
-Python package to interact with the Phenoscape Knowledgebase
+
+Python package to interact with the [Phenoscape Knowledgebase API](https://kb.phenoscape.org/api/v2/docs/).
+
+## Installation
+
+```
+pip install --upgrade pip
+pip install git+https://github.com/Imageomics/pyphenoscape
+```
+
+## Usage
+
+Import main package as "pkb":
+
+```
+import phenoscape.kb as pkb
+```
+
+### Search for terms
+
+Use the `pkb.term_search` function to search for "dorsal fin".
+
+```python
+terms = pkb.term_search("dorsal fin")
+print("Found", len(terms), "terms.")
+
+first_term = terms[0]
+print("First term:")
+print("\tlabel:", first_term['label'])
+print("\tmatchType:", first_term['matchType'])
+print("\t@id:", first_term['@id'])
+print("\tisDefinedBy:", first_term['isDefinedBy'])
+```
+
+Output:
+
+```
+Found 100 terms.
+First term:
+	label: dorsal fin
+	matchType: exact
+	@id: http://purl.obolibrary.org/obo/UBERON_0003097
+	isDefinedBy: http://purl.obolibrary.org/obo/uberon.owl
+```
+
+### Search for exact terms
+
+Use the `pkb.term_search` function to search for "dorsal fin".
+
+```python
+terms = pkb.term_search("dorsal fin", match_types=["exact"])
+print("Found", len(terms), "terms.")
+print("Term IRI", terms[0]["@id"])
+```
+
+Output:
+
+```
+Found 1 terms.
+Term IRI http://purl.obolibrary.org/obo/UBERON_0003097
+```
+
+### Lookup information about a term IRI
+
+```python
+term_details = pkb.get_term("http://purl.obolibrary.org/obo/UBERON_0003097")
+print("Label", term_details["label"])
+print("Definition", term_details["definition"])
+print()
+print(term_details)
+```
+
+Output:
+
+```
+Term IRI http://purl.obolibrary.org/obo/UBERON_0003097
+Label dorsal fin
+Definition Median fin located on the dorsal surface of the organism.
+
+{'synonyms': [], 'label': 'dorsal fin', 'relationships': [{'property': {'@id': 'http://purl.obolibrary.org/obo/BSPO_0005001', 'label': 'intersects midsagittal plane of'}, 'value': {'@id': 'http://purl.obolibrary.org/obo/UBERON_00...
+```
+
+## Run Tests
+
+From a clone of this repo within a python environment run:
+
+```
+pip install --upgrade pip
+pip install -e .[test]
+tox
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,38 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "phenoscape"
+version = "0.0.1"
+authors = [
+  { name="John Bradley", email="john.bradley@duke.edu" },
+]
+description = "Python package to interact with the Phenoscape Knowledgebase"
+readme = "README.md"
+requires-python = ">=3.7"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+]
+dependencies = [
+  'requests'
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "tox"
+]
+
+[project.urls]
+"Homepage" = "https://github.com/Imageomics/pyphenoscape"
+"Bug Tracker" = "https://github.com/Imageomics/pyphenoscape/issues"
+
+
+[tool.pytest.ini_options]
+addopts = [
+    "--import-mode=importlib",
+]
+pythonpath = "src"

--- a/src/phenoscape/kb.py
+++ b/src/phenoscape/kb.py
@@ -1,0 +1,60 @@
+import os
+import requests
+
+KB_API_URL = os.environ.get("KB_API_URL", "https://kb.phenoscape.org/api/v2")
+
+
+def _get_kb_json_response(path, params):
+    """Performs GET request to KB API for path and params.
+
+    Parameters:
+    path (str): Path added to end of the KB API URL.
+    params (dict): Key/values to be passed to KB API.
+
+    Returns:
+    dict: Dictionary or list from KB API.
+    """
+    response = requests.get(f"{KB_API_URL}{path}", params=params)
+    response.raise_for_status()
+    return response.json()
+
+
+def get_term(iri):
+    """Returns a dictionary of info for a term IRI.
+
+    Parameters:
+    iri (str): IRI of the term to fetch info about.
+
+    Returns:
+    dict: Dictionary response from /term KB API
+    """
+    return _get_kb_json_response("/term", {"iri": iri})
+
+
+def term_search(text, match_types=None):
+    """Returns a list of terms(dict) for search text, optionally filtering by match_types.
+
+    Parameters:
+    text (str): Term text to search for.
+    match_type ([str]): Array of types of search matches to return.
+        Allowable str values are "exact", "partial", and "broad".
+
+    Returns:
+    [dict]: list of terms(dicts) found.
+
+    Raises:
+        ValueError: If `match_types` contains invalid values.
+    """
+    if match_types:
+        for mt in match_types:
+            if not mt in ["exact", "partial", "broad"]:
+                raise ValueError(
+                    f"Invalid match_types parameter ({match_types}). "
+                    "Valid match types are 'exact', 'partial', and 'broad'."
+                )
+
+    data = _get_kb_json_response("/term/search", {"text": text})
+    items = data["results"]
+    if match_types:
+        items = [item for item in items if item["matchType"] in match_types]
+    return items

--- a/src/phenoscape/test_kb.py
+++ b/src/phenoscape/test_kb.py
@@ -1,0 +1,57 @@
+import unittest
+from unittest.mock import patch, Mock
+import phenoscape.kb as pkb
+
+
+class TestTermFunctions(unittest.TestCase):
+    @patch("phenoscape.kb.requests")
+    def test_get_term(self, mock_requests):
+        response = Mock()
+        mock_requests.get.return_value = response
+        response.json.return_value = {"@id": "someIRI"}
+
+        result = pkb.get_term(iri="http://purl.obolibrary.org/obo/UBERON_0011618")
+
+        self.assertEqual(result, {"@id": "someIRI"})
+        mock_requests.get.assert_called_with(
+            f"{pkb.KB_API_URL}/term",
+            params={"iri": "http://purl.obolibrary.org/obo/UBERON_0011618"},
+        )
+
+    @patch("phenoscape.kb.requests")
+    def test_term_search(self, mock_requests):
+        response = Mock()
+        mock_requests.get.return_value = response
+        response.json.return_value = {
+            "results": [
+                {"@id": "someIRI", "matchType": "exact"},
+                {"@id": "otherIRI", "matchType": "broad"},
+            ]
+        }
+
+        result = pkb.term_search(text="dorsal fin", match_types=["exact"])
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0], {"@id": "someIRI", "matchType": "exact"})
+        mock_requests.get.assert_called_with(
+            f"{pkb.KB_API_URL}/term/search", params={"text": "dorsal fin"}
+        )
+
+    @patch("phenoscape.kb.requests")
+    def test_term_search_bad_match_types(self, mock_requests):
+        response = Mock()
+        mock_requests.get.return_value = response
+        response.json.return_value = {
+            "results": [
+                {"@id": "someIRI", "matchType": "exact"},
+                {"@id": "otherIRI", "matchType": "broad"},
+            ]
+        }
+        with self.assertRaises(ValueError) as raised_exception:
+            pkb.term_search(text="dorsal fin", match_types=["best"])
+        expected_error = "Invalid match_types parameter (['best']). Valid match types are 'exact', 'partial', and 'broad'."
+        self.assertEqual(str(raised_exception.exception), expected_error)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,14 @@
+[tox]
+min_version = 4.0
+env_list = py311, lint
+
+[testenv]
+deps = pytest
+commands = pytest
+
+[testenv:lint]
+description = run linters
+skip_install = true
+deps =
+    black==22.12
+commands = black {posargs:.}


### PR DESCRIPTION
Adds phenoscape package containing term_search and get_term functions. Usage:
```
import phenoscape.kb as pkb

terms = pkb.term_search("dorsal fin")
for term in terms:
    print(term)

term_details = pkb.get_term("http://purl.obolibrary.org/obo/UBERON_0003097")
print(term_details)
```

Fixes #1